### PR TITLE
Enable background service and notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="pomodoro"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,9 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSUserNotificationUsageDescription</key>
+        <string>Esta aplicación usa notificaciones para recordarte tus sesiones</string>
 </dict>
 </plist>

--- a/lib/features/data/data.dart
+++ b/lib/features/data/data.dart
@@ -46,7 +46,7 @@ class _DataState extends State<Data> {
           _longestSesh = int.parse(_sessions[i]!.split(' ')[1]);
         }
       }
-      _avgSesh = _totalMin / _seshNum;
+      _avgSesh = _seshNum == 0 ? 0 : _totalMin / _seshNum;
     });
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 
 import 'package:pomodoro/utils/app.dart';
-import 'package:pomodoro/utils/notifications/notifications.dart'; // Importa el servicio
+import 'package:pomodoro/utils/notifications/notifications.dart';
+import 'package:pomodoro/utils/background_service.dart';
 
 void main() async {
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
   WidgetsFlutterBinding.ensureInitialized();
+  await initializeService();
   await NotificationService.initialize(); // Ya no pasa context
   await NotificationService.requestPermissions();
 

--- a/lib/utils/background_service.dart
+++ b/lib/utils/background_service.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:flutter_background_service_android/flutter_background_service_android.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+
+import 'notifications/notifications.dart';
+
+Future<void> initializeService() async {
+  final service = FlutterBackgroundService();
+
+  await service.configure(
+    androidConfiguration: AndroidConfiguration(
+      onStart: onStart,
+      autoStart: true,
+      isForegroundMode: true,
+      notificationChannelId: 'pomodoro_service',
+      initialNotificationTitle: 'Pomodoro',
+      initialNotificationContent: 'Servicio iniciado',
+    ),
+    iosConfiguration: IosConfiguration(
+      onForeground: onStart,
+      onBackground: onIosBackground,
+    ),
+  );
+
+  await service.startService();
+}
+
+@pragma('vm:entry-point')
+void onStart(ServiceInstance service) async {
+  DartPluginRegistrant.ensureInitialized();
+
+  if (service is AndroidServiceInstance) {
+    service.setForegroundNotificationInfo(
+      title: 'Pomodoro',
+      content: 'El temporizador está activo',
+    );
+  }
+
+  Timer.periodic(const Duration(minutes: 1), (timer) async {
+    await NotificationService.showTimerNotification(
+      id: 0,
+      title: 'Pomodoro',
+      body: 'El temporizador continúa en segundo plano',
+    );
+  });
+}
+
+@pragma('vm:entry-point')
+Future<bool> onIosBackground(ServiceInstance service) async {
+  DartPluginRegistrant.ensureInitialized();
+  return true;
+}

--- a/lib/utils/timer.dart
+++ b/lib/utils/timer.dart
@@ -138,11 +138,21 @@ class TimerState extends State<MyTimer> {
             _time = Duration(minutes: _timeInt);
             _currMax = _timeInt;
             _timerCount++;
+            NotificationService.showTimerNotification(
+              id: 1,
+              title: 'Pomodoro',
+              body: 'Comienza una nueva sesión de trabajo',
+            );
           } else {
             _time = _break;
             _currMax = _break.inMinutes;
             _counter++;
             _timerCount++;
+            NotificationService.showTimerNotification(
+              id: 2,
+              title: 'Pomodoro',
+              body: 'Hora de descansar',
+            );
           }
           if (_counter > _sessionCount) {
             final isMobile = context.isMobile;
@@ -196,6 +206,11 @@ class TimerState extends State<MyTimer> {
             ).show(context);
             FocusManager.instance.primaryFocus?.unfocus();
             _storeTime();
+            NotificationService.showTimerNotification(
+              id: 3,
+              title: 'Pomodoro',
+              body: 'Todas las sesiones completadas',
+            );
             Navigator.pop(context);
           }
 


### PR DESCRIPTION
## Summary
- add Android POST_NOTIFICATIONS permission
- ask for notification permission on iOS
- implement background service
- trigger local notifications from timer
- avoid divide by zero in data calculations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858688e2d9c832f8779a09febe5d4d4